### PR TITLE
Introduced several minor additions

### DIFF
--- a/disable-comments.php
+++ b/disable-comments.php
@@ -134,6 +134,7 @@ class Disable_Comments {
 		// These can happen later
 		add_action( 'plugins_loaded', array( $this, 'register_text_domain' ) );
 		add_action( 'wp_loaded', array( $this, 'init_wploaded_filters' ) );
+		add_action( 'add_meta_boxes', array( $this, 'remove_comments_metabox_post_types' ), 99);
 	}
 
 	public function register_text_domain() {
@@ -344,6 +345,18 @@ jQuery(document).ready(function($){
 	public function disable_rc_widget() {
 		// This widget has been removed from the Dashboard in WP 3.8 and can be removed in a future version
 		unregister_widget( 'WP_Widget_Recent_Comments' );
+	}
+
+	public function remove_comments_metabox_post_types() {
+		// Remove meta boxes for comments, discussion and trackbacks metaboxes in post types
+		$disabled_post_types = $this->get_disabled_post_types();
+		if( !empty( $disabled_post_types ) ) {
+			foreach( $disabled_post_types as $type ) {
+		        remove_meta_box('commentsdiv', $type, 'normal');
+		        remove_meta_box('commentsstatusdiv', $type, 'normal');
+		        remove_meta_box('trackbacksdiv', $type, 'normal');
+		    }
+	    }
 	}
 
 	public function set_plugin_meta( $links, $file ) {

--- a/disable-comments.php
+++ b/disable-comments.php
@@ -152,6 +152,7 @@ class Disable_Comments {
 					remove_post_type_support( $type, 'trackbacks' );
 				}
 			}
+			add_filter( 'comments_array', 'filter_existing_comments', 20, 2 );
 			add_filter( 'comments_open', array( $this, 'filter_comment_status' ), 20, 2 );
 			add_filter( 'pings_open', array( $this, 'filter_comment_status' ), 20, 2 );
 		}
@@ -335,6 +336,11 @@ jQuery(document).ready(function($){
 		else {
 			echo '<script> jQuery(function($){ $("#dashboard_right_now .comment-count, #latest-comments").hide(); }); </script>';
 		}
+	}
+
+	public function filter_existing_comments($comments, $post_id) {
+		$post = get_post( $post_id );
+		return ( $this->options['remove_everywhere'] || $this->is_post_type_disabled( $post->post_type ) ) ? array() : $comments;
 	}
 
 	public function filter_comment_status( $open, $post_id ) {

--- a/disable-comments.php
+++ b/disable-comments.php
@@ -195,7 +195,7 @@ class Disable_Comments {
 
 			if( $this->options['remove_everywhere'] ) {
 				add_filter( 'feed_links_show_comments_feed', '__return_false' );
-				add_action( 'wp_head', array( $this, 'hide_meta_widget_link' ) );
+				add_action( 'wp_footer', array( $this, 'hide_meta_widget_link' ) );
 			}
 		}
 	}
@@ -341,7 +341,9 @@ jQuery(document).ready(function($){
 	}
 
 	public function hide_meta_widget_link(){
-		echo '<script> jQuery(function($){ $(".widget_meta a[href=\'' . esc_url( get_bloginfo( 'comments_rss2_url' ) ) . '\']").parent().hide(); }); </script>';
+		if ( is_active_widget( false, false, 'meta', true ) ) {
+			echo '<script> jQuery(function($){ $(".widget_meta a[href=\'' . esc_url( get_bloginfo( 'comments_rss2_url' ) ) . '\']").parent().hide(); }); </script>';
+		}
 	}
 
 	public function filter_existing_comments($comments, $post_id) {

--- a/disable-comments.php
+++ b/disable-comments.php
@@ -394,7 +394,8 @@ jQuery(document).ready(function($){
 	}
 
 	public function settings_page() {
-		include dirname( __FILE__ ) . '/includes/settings-page.php';
+		include dirname( __FILE__ ) . '/includes/disable-comments-form.php';
+		include dirname( __FILE__ ) . '/includes/delete-comments-form.php';
 	}
 
 	private function enter_permanent_mode() {

--- a/disable-comments.php
+++ b/disable-comments.php
@@ -336,6 +336,7 @@ jQuery(document).ready(function($){
 		else {
 			echo '<script> jQuery(function($){ $("#dashboard_right_now .comment-count, #latest-comments").hide(); }); </script>';
 		}
+		echo '<script> jQuery(function($){ $("#welcome-panel .welcome-comments").parent().hide(); }); </script>';
 	}
 
 	public function filter_existing_comments($comments, $post_id) {

--- a/disable-comments.php
+++ b/disable-comments.php
@@ -195,6 +195,7 @@ class Disable_Comments {
 
 			if( $this->options['remove_everywhere'] ) {
 				add_filter( 'feed_links_show_comments_feed', '__return_false' );
+				add_action( 'wp_head', array( $this, 'hide_meta_widget_link' ) );
 			}
 		}
 	}
@@ -337,6 +338,10 @@ jQuery(document).ready(function($){
 			echo '<script> jQuery(function($){ $("#dashboard_right_now .comment-count, #latest-comments").hide(); }); </script>';
 		}
 		echo '<script> jQuery(function($){ $("#welcome-panel .welcome-comments").parent().hide(); }); </script>';
+	}
+
+	public function hide_meta_widget_link(){
+		echo '<script> jQuery(function($){ $(".widget_meta a[href=\'' . esc_url( get_bloginfo( 'comments_rss2_url' ) ) . '\']").parent().hide(); }); </script>';
 	}
 
 	public function filter_existing_comments($comments, $post_id) {

--- a/disable-comments.php
+++ b/disable-comments.php
@@ -134,7 +134,6 @@ class Disable_Comments {
 		// These can happen later
 		add_action( 'plugins_loaded', array( $this, 'register_text_domain' ) );
 		add_action( 'wp_loaded', array( $this, 'init_wploaded_filters' ) );
-		add_action( 'add_meta_boxes', array( $this, 'remove_comments_metabox_post_types' ), 99);
 	}
 
 	public function register_text_domain() {
@@ -359,18 +358,6 @@ jQuery(document).ready(function($){
 	public function disable_rc_widget() {
 		// This widget has been removed from the Dashboard in WP 3.8 and can be removed in a future version
 		unregister_widget( 'WP_Widget_Recent_Comments' );
-	}
-
-	public function remove_comments_metabox_post_types() {
-		// Remove meta boxes for comments, discussion and trackbacks metaboxes in post types
-		$disabled_post_types = $this->get_disabled_post_types();
-		if( !empty( $disabled_post_types ) ) {
-			foreach( $disabled_post_types as $type ) {
-		        remove_meta_box('commentsdiv', $type, 'normal');
-		        remove_meta_box('commentsstatusdiv', $type, 'normal');
-		        remove_meta_box('trackbacksdiv', $type, 'normal');
-		    }
-	    }
 	}
 
 	public function set_plugin_meta( $links, $file ) {

--- a/includes/delete-comments-form.php
+++ b/includes/delete-comments-form.php
@@ -1,0 +1,122 @@
+<?php
+if( !defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<div class="wrap">
+<h1><?php _e( 'Delete Comments', 'disable-comments') ?></h1>
+<?php
+
+global $wpdb;
+$comments_count = $wpdb->get_var("SELECT count(comment_id) from $wpdb->comments");
+if ( $comments_count <= 0 ) { ?>
+<p><strong>No comments available for deletion.</strong></p>
+</div>
+<?php
+	exit;
+}
+
+$typeargs = array( 'public' => true );
+if( $this->networkactive ) {
+	$typeargs['_builtin'] = true;	// stick to known types for network
+}
+$types = get_post_types( $typeargs, 'objects' );
+foreach( array_keys( $types ) as $type ) {
+	if( ! in_array( $type, $this->modified_types ) && ! post_type_supports( $type, 'comments' ) )	// the type doesn't support comments anyway
+		unset( $types[$type] );
+}
+
+if ( isset( $_POST['delete'] ) && isset( $_POST['delete_mode'] ) ) {
+	check_admin_referer( 'delete-comments-admin' );
+
+	if( $_POST['delete_mode'] == 'delete_everywhere' ) {
+		if ( $wpdb->query( "TRUNCATE $wpdb->commentmeta" ) != FALSE ){
+            if ( $wpdb->query( "TRUNCATE $wpdb->comments" ) != FALSE ){
+                $wpdb->query( "UPDATE $wpdb->posts SET comment_count = 0 WHERE post_author != 0" );
+                $wpdb->query( "OPTIMIZE TABLE $wpdb->commentmeta" );
+                $wpdb->query( "OPTIMIZE TABLE $wpdb->comments" );
+            	echo "<p style='color:green'><strong>" . __( 'All comments have been deleted.', 'disable-comments' ) . "</strong></p>";
+            } else {
+	            echo "<p style='color:red'><strong>" . __( 'Internal error occured. Please try again later.', 'disable-comments' ) . "</strong></p>";
+            }
+        } else {
+            echo "<p style='color:red'><strong>" . __( 'Internal error occured. Please try again later.', 'disable-comments' ) . "</strong></p>";
+        }
+	} else {
+		$delete_post_types =  empty( $_POST['delete_types'] ) ? array() : (array) $_POST['delete_types'];
+		$delete_post_types = array_intersect( $delete_post_types, array_keys( $types ) );
+
+		// Extra custom post types
+		if( $this->networkactive && !empty( $_POST['delete_extra_post_types'] ) ) {
+			$delete_extra_post_types = array_filter( array_map( 'sanitize_key', explode( ',', $_POST['delete_extra_post_types'] ) ) );
+			$delete_extra_post_types = array_diff( $delete_extra_post_types, array_keys( $types ) );	// Make sure we don't double up builtins
+			$delete_post_types = array_merge($delete_post_types, $delete_extra_post_types);
+		}
+
+		if ( ! empty( $delete_post_types ) ) {
+			// Loop through post_types and remove comments/meta and set posts comment_count to 0
+			foreach ( $delete_post_types as $delete_post_type ) {
+                $wpdb->query( "DELETE cmeta FROM $wpdb->commentmeta cmeta INNER JOIN $wpdb->comments comments ON cmeta.comment_id=comments.comment_ID INNER JOIN $wpdb->posts posts ON comments.comment_post_ID=posts.ID WHERE posts.post_type = '$delete_post_type'" );
+                $wpdb->query( "DELETE comments FROM $wpdb->comments comments INNER JOIN $wpdb->posts posts ON comments.comment_post_ID=posts.ID WHERE posts.post_type = '$delete_post_type'" );
+                $wpdb->query( "UPDATE $wpdb->posts SET comment_count = 0 WHERE post_author != 0 AND post_type = '$delete_post_type'" );
+				echo "<p style='color:green'><strong>" . sprintf( __( 'All comments have been deleted for %ss.', 'disable-comments' ), $delete_post_type ) . "</strong></p>";
+			}
+
+            $wpdb->query( "OPTIMIZE TABLE $wpdb->commentmeta" );
+            $wpdb->query( "OPTIMIZE TABLE $wpdb->comments" );
+
+            echo "<h4 style='color:green'><strong>" . __( 'Comment Deletion Complete', 'disable-comments') . "</strong></h4>";
+		}
+
+	}
+
+	$comments_count = $wpdb->get_var("SELECT count(comment_id) from $wpdb->comments");
+	if ( $comments_count <= 0 ) { ?>
+		<p><strong>No comments available for deletion.</strong></p>
+		</div>
+	<?php
+		exit;
+	}
+
+}
+?>
+<form action="" method="post" id="delete-comments">
+<ul>
+<li><label for="delete_everywhere"><input type="radio" id="delete_everywhere" name="delete_mode" value="delete_everywhere" <?php checked( $this->options['remove_everywhere'] );?> /> <strong><?php _e( 'Everywhere', 'disable-comments') ?></strong>: <?php _e( 'Delete all comments in WordPress.', 'disable-comments') ?></label>
+	<p class="indent"><?php printf( __( '%s: This function and will affect your entire site. Use it only if you want to delete comments <em>everywhere</em>.', 'disable-comments' ), '<strong style="color: #900">' . __('Warning', 'disable-comments') . '</strong>' ); ?></p>
+</li>
+<li><label for="selected_delete_types"><input type="radio" id="selected_delete_types" name="delete_mode" value="selected_delete_types" <?php checked( ! $this->options['remove_everywhere'] );?> /> <strong><?php _e( 'For certain post types', 'disable-comments') ?></strong>:</label>
+	<p></p>
+	<ul class="indent" id="listofdeletetypes">
+		<?php foreach( $types as $k => $v ) echo "<li><label for='post-type-$k'><input type='checkbox' name='delete_types[]' value='$k' ". checked( in_array( $k, $this->options['disabled_post_types'] ), true, false ) ." id='post-type-$k'> {$v->labels->name}</label></li>";?>
+	</ul>
+	<?php if( $this->networkactive ) :?>
+	<p class="indent" id="extradeletetypes"><?php _e( 'Only the built-in post types appear above. If you want to disable comments on other custom post types on the entire network, you can supply a comma-separated list of post types below (use the slug that identifies the post type).', 'disable-comments' ); ?>
+	<br /><label>Custom post types: <input type="text" name="delete_extra_post_types" size="30" value="<?php echo implode( ', ', (array) $this->options['extra_post_types'] ); ?>" /></label></p>
+	<?php endif; ?>
+	<p class="indent"><?php printf( __( '%s: Deleting comments will remove existing comment entries in the database and cannot be reverted without a database backup.', 'disable-comments'), '<strong style="color: #900">' . __('Warning', 'disable-comments') . '</strong>' ); ?></p>
+</li>
+</ul>
+
+<?php wp_nonce_field( 'delete-comments-admin' ); ?>
+<h4>Total Comments : <?php echo $comments_count; ?></h4>
+<p class="submit"><input class="button-primary" type="submit" name="delete" value="<?php _e( 'Delete Comments', 'disable-comments') ?>"></p>
+</form>
+</div>
+<script>
+jQuery(document).ready(function($){
+	function delete_comments_uihelper(){
+		var toggle_bits = $("#listofdeletetypes, #extradeletetypes");
+		if( $("#delete_everywhere").is(":checked") )
+			toggle_bits.css("color", "#888").find(":input").attr("disabled", true );
+		else
+			toggle_bits.css("color", "#000").find(":input").attr("disabled", false );
+	}
+
+	$("#delete-comments :input").change(function(){
+		delete_comments_uihelper();
+	});
+
+	delete_comments_uihelper();
+});
+</script>

--- a/includes/disable-comments-form.php
+++ b/includes/disable-comments-form.php
@@ -86,7 +86,7 @@ if( WP_CACHE )
 <?php endif; ?>
 
 <?php wp_nonce_field( 'disable-comments-admin' ); ?>
-<p class="submit"><input class="button-primary" type="submit" name="submit" value="<?php _e( 'Save Changes') ?>"></p>
+<p class="submit"><input class="button-primary" type="submit" name="submit" value="<?php _e( 'Save Changes', 'disable-comments') ?>"></p>
 </form>
 </div>
 <script>

--- a/readme.txt
+++ b/readme.txt
@@ -6,13 +6,15 @@ Requires at least: 4.0
 Tested up to: 4.5
 Stable tag: trunk
 
-Allows administrators to globally disable comments on their site. Comments can be disabled according to post type. Multisite friendly.
+Allows administrators to globally disable comments on their site. Comments can be disabled according to post type. Multisite friendly. Provides tool to delete all comments or according to post type.
 
 == Description ==
 
 This plugin allows administrators to globally disable comments on any post type (posts, pages, attachments, etc.) so that these settings cannot be overridden for individual posts. It also removes all comment-related fields from edit and quick-edit screens. On multisite installations, it can be used to disable comments on the entire network.
 
 Additionally, comment-related items can be removed from the Dashboard, Widgets, the Admin Menu and the Admin Bar.
+
+**NEW**: You can also delete all comments or according to post type.
 
 **Important note**: Use this plugin if you don't want comments at all on your site (or on certain post types). Don't use it if you want to selectively disable comments on individual posts - WordPress lets you do that anyway. If you don't know how to disable comments on individual posts, there are instructions in [the FAQ](http://wordpress.org/extend/plugins/disable-comments/faq/).
 
@@ -44,6 +46,10 @@ Go to the edit page for the post you want to disable comments on. Scroll down to
 
 You can also bulk-edit the comment status of multiple posts from the [posts screen](http://codex.wordpress.org/Posts_Screen).
 
+= I want to delete comments from my database. What do I do? =
+
+Go to the settings page for the disable comments plugin and utlize the Delete Comments tool to delete all comments or according to the specified post types from your database.
+
 == Details ==
 
 The plugin provides the option to **completely disable the commenting feature in WordPress**. When this option is selected, the following changes are made:
@@ -56,7 +62,7 @@ The plugin provides the option to **completely disable the commenting feature in
 * The X-Pingback HTTP header is removed from all pages;
 * Outgoing pingbacks are disabled.
 
-**Please delete any existing comments on your site before applying this setting, otherwise (depending on your theme) those comments may still be displayed to visitors.**
+**Please delete any existing comments on your site before applying this setting, otherwise (depending on your theme) those comments may still be displayed to visitors. You can now use the Delete Comments tool to delete any existing comments on your site.**
 
 == Advanced Configuration ==
 


### PR DESCRIPTION
Hello,

I wanted to merge some code from my remove-comments.php script attached;
[remove-comments.php.zip](https://github.com/solarissmoke/disable-comments/files/263945/remove-comments.php.zip)

Below is a list of items added;
1. Disabling the Comments, Discussion and Trackbacks Metaboxes (#29)
2. Emptying the Comments_Array
3. Removing the 'Turn comments on and off' link in the Wordpress Welcome (#30)
4. Removing the 'Comments RSS' link within the Meta Widget (#31)

Let me know if you find any issues with these changes.

Thanks