### PR TITLE
[WIP] Change wp_die() to wp_redirect() with permanently moved status

### DIFF
--- a/disable-comments.php
+++ b/disable-comments.php
@@ -235,7 +235,11 @@ class Disable_Comments {
 	 */
 	public function filter_query() {
 		if( is_comment_feed() ) {
-			wp_die( __( 'Comments are closed.' ), '', array( 'response' => 403 ) );
+			$refere = isset($_SERVER['HTTP_REFERER'])? $_SERVER['HTTP_REFERER']: '';
+			$location = !empty($refere)? htmlspecialchars($refere): home_url('/');
+			$status = 301;
+			wp_redirect($location, $status);
+			exit;
 		}
 	}
 


### PR DESCRIPTION
To Disable for clients to see Wordpress error page.

- [x] Redirect home when client access comment feed
- [ ] Switch redirected page based on archive or single

In future, redirect to relation template.