### PR TITLE
Initial implementation of filter_comments_number w/ unit tests

### DIFF
--- a/disable-comments.php
+++ b/disable-comments.php
@@ -154,6 +154,7 @@ class Disable_Comments {
 			add_filter( 'comments_array', array( $this, 'filter_existing_comments' ), 20, 2 );
 			add_filter( 'comments_open', array( $this, 'filter_comment_status' ), 20, 2 );
 			add_filter( 'pings_open', array( $this, 'filter_comment_status' ), 20, 2 );
+			add_filter( 'get_comments_number', array( $this, 'filter_comments_number' ), 20, 2 );
 		}
 		elseif( is_admin() && !$this->options['remove_everywhere'] ) {
 			// It is possible that $disabled_post_types is empty if other
@@ -343,6 +344,11 @@ class Disable_Comments {
 	public function filter_comment_status( $open, $post_id ) {
 		$post = get_post( $post_id );
 		return ( $this->options['remove_everywhere'] || $this->is_post_type_disabled( $post->post_type ) ) ? false : $open;
+	}
+
+	public function filter_comments_number( $count, $post_id ) {
+		$post = get_post( $post_id );
+		return ( $this->options['remove_everywhere'] || $this->is_post_type_disabled( $post->post_type ) ) ? 0 : $count;
 	}
 
 	public function disable_rc_widget() {

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -36,6 +36,7 @@ class RemoveEveryWhereTestCase extends WP_UnitTestCase {
 		$this->assertEquals( 20,  has_action( 'comments_array', array( $this->plugin_instance, 'filter_existing_comments' ) ) );
 		$this->assertEquals( 20,  has_action( 'comments_open', array( $this->plugin_instance, 'filter_comment_status' ) ) );
 		$this->assertEquals( 20,  has_action( 'pings_open', array( $this->plugin_instance, 'filter_comment_status' ) ) );
+		$this->assertEquals( 20,  has_action( 'get_comments_number', array( $this->plugin_instance, 'filter_comments_number' ) ) );
 
 		// Check that comment suport has been removed from all the post types
 		$this->assertFalse( post_type_supports( 'post', 'comments' ) );
@@ -94,6 +95,12 @@ class RemoveEveryWhereTestCase extends WP_UnitTestCase {
 		$output = $this->plugin_instance->filter_comment_status( 'open', $post_id );
 		$this->assertFalse($output);
 	}
+
+	function test_filter_comments_number() {
+		$post_id = $this->factory->post->create();
+		$output = $this->plugin_instance->filter_comments_number( 5, $post_id );
+		$this->assertEquals(0, $output);
+	}
 }
 
 
@@ -120,6 +127,7 @@ class RemoveIndividualTestCase extends WP_UnitTestCase {
 		$this->assertEquals( 20,  has_action( 'comments_array', array( $this->plugin_instance, 'filter_existing_comments' ) ) );
 		$this->assertEquals( 20,  has_action( 'comments_open', array( $this->plugin_instance, 'filter_comment_status' ) ) );
 		$this->assertEquals( 20,  has_action( 'pings_open', array( $this->plugin_instance, 'filter_comment_status' ) ) );
+		$this->assertEquals( 20,  has_action( 'get_comments_number', array( $this->plugin_instance, 'filter_comments_number' ) ) );
 
 		// Check that comment suport has been removed only from posts
 		$this->assertFalse( post_type_supports( 'post', 'comments' ) );
@@ -148,5 +156,17 @@ class RemoveIndividualTestCase extends WP_UnitTestCase {
 		$post_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
 		$output = $this->plugin_instance->filter_comment_status( 'open', $post_id );
 		$this->assertEquals( 'open', $output );
+	}
+
+	function test_filter_comments_number_on_disabled_type() {
+		$post_id = $this->factory->post->create();
+		$output = $this->plugin_instance->filter_comments_number( 5, $post_id );
+		$this->assertEquals(0, $output);
+	}
+
+	function test_filter_comments_number_on_enabled_type() {
+		$post_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$output = $this->plugin_instance->filter_comments_number( 5, $post_id );
+		$this->assertEquals(5, $output);
 	}
 }


### PR DESCRIPTION
This PR is to implement a filter on get_comments_number as mentioned and to fix #56.

The filter_comments_number is applied in the same fashion as the filter_existing_comments and I've updated the unit tests to add coverage for the new code.

Let me know if you have any issues with it.
Thanks