### PR TITLE
Fix PHP Coding Style via phpcbf(PHP Code Beautifier and Fixer)

### DIFF
--- a/disable-comments.php
+++ b/disable-comments.php
@@ -11,11 +11,12 @@ Text Domain: disable-comments
 Domain Path: /languages/
 */
 
-if( !defined( 'ABSPATH' ) )
+if ( ! defined( 'ABSPATH' ) ) {
 	exit;
+}
 
 class Disable_Comments {
-	const DB_VERSION = 6;
+	const DB_VERSION         = 6;
 	private static $instance = null;
 	private $options;
 	private $networkactive;
@@ -33,15 +34,14 @@ class Disable_Comments {
 		$this->networkactive = ( is_multisite() && array_key_exists( plugin_basename( __FILE__ ), (array) get_site_option( 'active_sitewide_plugins' ) ) );
 
 		// Load options
-		if( $this->networkactive ) {
+		if ( $this->networkactive ) {
 			$this->options = get_site_option( 'disable_comments_options', array() );
-		}
-		else {
+		} else {
 			$this->options = get_option( 'disable_comments_options', array() );
 		}
 
 		// If it looks like first run, check compat
-		if( empty( $this->options ) ) {
+		if ( empty( $this->options ) ) {
 			$this->check_compatibility();
 		}
 
@@ -63,22 +63,23 @@ class Disable_Comments {
 
 	private function check_db_upgrades() {
 		$old_ver = isset( $this->options['db_version'] ) ? $this->options['db_version'] : 0;
-		if( $old_ver < self::DB_VERSION ) {
-			if( $old_ver < 2 ) {
+		if ( $old_ver < self::DB_VERSION ) {
+			if ( $old_ver < 2 ) {
 				// upgrade options from version 0.2.1 or earlier to 0.3
 				$this->options['disabled_post_types'] = get_option( 'disable_comments_post_types', array() );
 				delete_option( 'disable_comments_post_types' );
 			}
-			if( $old_ver < 5 ) {
+			if ( $old_ver < 5 ) {
 				// simple is beautiful - remove multiple settings in favour of one
 				$this->options['remove_everywhere'] = isset( $this->options['remove_admin_menu_comments'] ) ? $this->options['remove_admin_menu_comments'] : false;
-				foreach( array( 'remove_admin_menu_comments', 'remove_admin_bar_comments', 'remove_recent_comments', 'remove_discussion', 'remove_rc_widget' ) as $v )
-					unset( $this->options[$v] );
+				foreach ( array( 'remove_admin_menu_comments', 'remove_admin_bar_comments', 'remove_recent_comments', 'remove_discussion', 'remove_rc_widget' ) as $v ) {
+					unset( $this->options[ $v ] );
+				}
 			}
 
-			foreach( array( 'remove_everywhere', 'extra_post_types' ) as $v ) {
-				if( !isset( $this->options[$v] ) ) {
-					$this->options[$v] = false;
+			foreach ( array( 'remove_everywhere', 'extra_post_types' ) as $v ) {
+				if ( ! isset( $this->options[ $v ] ) ) {
+					$this->options[ $v ] = false;
 				}
 			}
 
@@ -88,10 +89,9 @@ class Disable_Comments {
 	}
 
 	private function update_options() {
-		if( $this->networkactive ) {
+		if ( $this->networkactive ) {
 			update_site_option( 'disable_comments_options', $this->options );
-		}
-		else {
+		} else {
 			update_option( 'disable_comments_options', $this->options );
 		}
 	}
@@ -102,9 +102,9 @@ class Disable_Comments {
 	private function get_disabled_post_types() {
 		$types = $this->options['disabled_post_types'];
 		// Not all extra_post_types might be registered on this particular site
-		if( $this->networkactive ) {
-			foreach( (array) $this->options['extra_post_types'] as $extra ) {
-				if( post_type_exists( $extra ) ) {
+		if ( $this->networkactive ) {
+			foreach ( (array) $this->options['extra_post_types'] as $extra ) {
+				if ( post_type_exists( $extra ) ) {
 					$types[] = $extra;
 				}
 			}
@@ -121,10 +121,10 @@ class Disable_Comments {
 
 	private function init_filters() {
 		// These need to happen now
-		if( $this->options['remove_everywhere'] ) {
+		if ( $this->options['remove_everywhere'] ) {
 			add_action( 'widgets_init', array( $this, 'disable_rc_widget' ) );
 			add_filter( 'wp_headers', array( $this, 'filter_wp_headers' ) );
-			add_action( 'template_redirect', array( $this, 'filter_query' ), 9 );	// before redirect_canonical
+			add_action( 'template_redirect', array( $this, 'filter_query' ), 9 );   // before redirect_canonical
 
 			// Admin bar filtering has to happen here since WP 3.6
 			add_action( 'template_redirect', array( $this, 'filter_admin_bar' ) );
@@ -137,15 +137,15 @@ class Disable_Comments {
 	}
 
 	public function register_text_domain() {
-		load_plugin_textdomain( 'disable-comments', false, dirname( plugin_basename( __FILE__ ) ) .  '/languages' );
+		load_plugin_textdomain( 'disable-comments', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
 	}
 
-	public function init_wploaded_filters(){
+	public function init_wploaded_filters() {
 		$disabled_post_types = $this->get_disabled_post_types();
-		if( !empty( $disabled_post_types ) ) {
-			foreach( $disabled_post_types as $type ) {
+		if ( ! empty( $disabled_post_types ) ) {
+			foreach ( $disabled_post_types as $type ) {
 				// we need to know what native support was for later
-				if( post_type_supports( $type, 'comments' ) ) {
+				if ( post_type_supports( $type, 'comments' ) ) {
 					$this->modified_types[] = $type;
 					remove_post_type_support( $type, 'comments' );
 					remove_post_type_support( $type, 'trackbacks' );
@@ -155,8 +155,7 @@ class Disable_Comments {
 			add_filter( 'comments_open', array( $this, 'filter_comment_status' ), 20, 2 );
 			add_filter( 'pings_open', array( $this, 'filter_comment_status' ), 20, 2 );
 			add_filter( 'get_comments_number', array( $this, 'filter_comments_number' ), 20, 2 );
-		}
-		elseif( is_admin() && !$this->options['remove_everywhere'] ) {
+		} elseif ( is_admin() && ! $this->options['remove_everywhere'] ) {
 			// It is possible that $disabled_post_types is empty if other
 			// plugins have disabled comments. Hence we also check for
 			// remove_everywhere. If you still get a warning you probably
@@ -165,25 +164,25 @@ class Disable_Comments {
 		}
 
 		// Filters for the admin only
-		if( is_admin() ) {
-			if( $this->networkactive ) {
+		if ( is_admin() ) {
+			if ( $this->networkactive ) {
 				add_action( 'network_admin_menu', array( $this, 'settings_menu' ) );
 				add_action( 'network_admin_menu', array( $this, 'tools_menu' ) );
-				add_filter( 'network_admin_plugin_action_links', array( $this, 'plugin_actions_links'), 10, 2 );
-			}
-			else {
+				add_filter( 'network_admin_plugin_action_links', array( $this, 'plugin_actions_links' ), 10, 2 );
+			} else {
 				add_action( 'admin_menu', array( $this, 'settings_menu' ) );
 				add_action( 'admin_menu', array( $this, 'tools_menu' ) );
-				add_filter( 'plugin_action_links', array( $this, 'plugin_actions_links'), 10, 2 );
-				if( is_multisite() )	// We're on a multisite setup, but the plugin isn't network activated.
+				add_filter( 'plugin_action_links', array( $this, 'plugin_actions_links' ), 10, 2 );
+				if ( is_multisite() ) {    // We're on a multisite setup, but the plugin isn't network activated.
 					register_deactivation_hook( __FILE__, array( $this, 'single_site_deactivate' ) );
+				}
 			}
 
 			add_action( 'admin_notices', array( $this, 'discussion_notice' ) );
 			add_filter( 'plugin_row_meta', array( $this, 'set_plugin_meta' ), 10, 2 );
 
-			if( $this->options['remove_everywhere'] ) {
-				add_action( 'admin_menu', array( $this, 'filter_admin_menu' ), 9999 );	// do this as late as possible
+			if ( $this->options['remove_everywhere'] ) {
+				add_action( 'admin_menu', array( $this, 'filter_admin_menu' ), 9999 );  // do this as late as possible
 				add_action( 'admin_print_styles-index.php', array( $this, 'admin_css' ) );
 				add_action( 'admin_print_styles-profile.php', array( $this, 'admin_css' ) );
 				add_action( 'wp_dashboard_setup', array( $this, 'filter_dashboard' ) );
@@ -194,7 +193,7 @@ class Disable_Comments {
 		else {
 			add_action( 'template_redirect', array( $this, 'check_comment_template' ) );
 
-			if( $this->options['remove_everywhere'] ) {
+			if ( $this->options['remove_everywhere'] ) {
 				add_filter( 'feed_links_show_comments_feed', '__return_false' );
 			}
 		}
@@ -206,8 +205,8 @@ class Disable_Comments {
 	 * and set it to True
 	 */
 	public function check_comment_template() {
-		if( is_singular() && ( $this->options['remove_everywhere'] || $this->is_post_type_disabled( get_post_type() ) ) ) {
-			if( !defined( 'DISABLE_COMMENTS_REMOVE_COMMENTS_TEMPLATE' ) || DISABLE_COMMENTS_REMOVE_COMMENTS_TEMPLATE == true ) {
+		if ( is_singular() && ( $this->options['remove_everywhere'] || $this->is_post_type_disabled( get_post_type() ) ) ) {
+			if ( ! defined( 'DISABLE_COMMENTS_REMOVE_COMMENTS_TEMPLATE' ) || DISABLE_COMMENTS_REMOVE_COMMENTS_TEMPLATE == true ) {
 				// Kill the comments template.
 				add_filter( 'comments_template', array( $this, 'dummy_comments_template' ), 20 );
 			}
@@ -235,7 +234,7 @@ class Disable_Comments {
 	 * Issue a 403 for all comment feed requests.
 	 */
 	public function filter_query() {
-		if( is_comment_feed() ) {
+		if ( is_comment_feed() ) {
 			wp_die( __( 'Comments are closed.' ), '', array( 'response' => 403 ) );
 		}
 	}
@@ -244,10 +243,10 @@ class Disable_Comments {
 	 * Remove comment links from the admin bar.
 	 */
 	public function filter_admin_bar() {
-		if( is_admin_bar_showing() ) {
+		if ( is_admin_bar_showing() ) {
 			// Remove comments links from admin bar
 			remove_action( 'admin_bar_menu', 'wp_admin_bar_comments_menu', 60 );
-			if( is_multisite() ) {
+			if ( is_multisite() ) {
 				add_action( 'admin_bar_menu', array( $this, 'remove_network_comment_links' ), 500 );
 			}
 		}
@@ -257,12 +256,11 @@ class Disable_Comments {
 	 * Remove comment links from the admin bar in a multisite network.
 	 */
 	public function remove_network_comment_links( $wp_admin_bar ) {
-		if( $this->networkactive && is_user_logged_in() ) {
-			foreach( (array) $wp_admin_bar->user->blogs as $blog ) {
+		if ( $this->networkactive && is_user_logged_in() ) {
+			foreach ( (array) $wp_admin_bar->user->blogs as $blog ) {
 				$wp_admin_bar->remove_menu( 'blog-' . $blog->userblog_id . '-c' );
 			}
-		}
-		else {
+		} else {
 			// We have no way to know whether the plugin is active on other sites, so only remove this one
 			$wp_admin_bar->remove_menu( 'blog-' . get_current_blog_id() . '-c' );
 		}
@@ -270,10 +268,11 @@ class Disable_Comments {
 
 	public function discussion_notice() {
 		$disabled_post_types = $this->get_disabled_post_types();
-		if( get_current_screen()->id == 'options-discussion' && !empty( $disabled_post_types ) ) {
+		if ( get_current_screen()->id == 'options-discussion' && ! empty( $disabled_post_types ) ) {
 			$names = array();
-			foreach( $disabled_post_types as $type )
-				$names[$type] = get_post_type_object( $type )->labels->name;
+			foreach ( $disabled_post_types as $type ) {
+				$names[ $type ] = get_post_type_object( $type )->labels->name;
+			}
 
 			echo '<div class="notice notice-warning"><p>' . sprintf( __( 'Note: The <em>Disable Comments</em> plugin is currently active, and comments are completely disabled on: %s. Many of the settings below will not be applicable for those post types.', 'disable-comments' ), implode( __( ', ' ), $names ) ) . '</p></div>';
 		}
@@ -283,7 +282,7 @@ class Disable_Comments {
 	 * Return context-aware settings page URL
 	 */
 	private function settings_page_url() {
-		$base =  $this->networkactive ? network_admin_url( 'settings.php' ) : admin_url( 'options-general.php' );
+		$base = $this->networkactive ? network_admin_url( 'settings.php' ) : admin_url( 'options-general.php' );
 		return add_query_arg( 'page', 'disable_comments_settings', $base );
 	}
 
@@ -291,40 +290,43 @@ class Disable_Comments {
 	 * Return context-aware tools page URL
 	 */
 	private function tools_page_url() {
-		$base =  $this->networkactive ? network_admin_url( 'settings.php' ) : admin_url( 'tools.php' );
+		$base = $this->networkactive ? network_admin_url( 'settings.php' ) : admin_url( 'tools.php' );
 		return add_query_arg( 'page', 'disable_comments_tools', $base );
 	}
 
-	public function setup_notice(){
-		if( strpos( get_current_screen()->id, 'settings_page_disable_comments_settings' ) === 0 )
+	public function setup_notice() {
+		if ( strpos( get_current_screen()->id, 'settings_page_disable_comments_settings' ) === 0 ) {
 			return;
+		}
 		$hascaps = $this->networkactive ? is_network_admin() && current_user_can( 'manage_network_plugins' ) : current_user_can( 'manage_options' );
-		if( $hascaps ) {
-			echo '<div class="updated fade"><p>' . sprintf( __( 'The <em>Disable Comments</em> plugin is active, but isn\'t configured to do anything yet. Visit the <a href="%s">configuration page</a> to choose which post types to disable comments on.', 'disable-comments'), esc_attr( $this->settings_page_url() ) ) . '</p></div>';
+		if ( $hascaps ) {
+			echo '<div class="updated fade"><p>' . sprintf( __( 'The <em>Disable Comments</em> plugin is active, but isn\'t configured to do anything yet. Visit the <a href="%s">configuration page</a> to choose which post types to disable comments on.', 'disable-comments' ), esc_attr( $this->settings_page_url() ) ) . '</p></div>';
 		}
 	}
 
-	public function filter_admin_menu(){
+	public function filter_admin_menu() {
 		global $pagenow;
 
-		if ( $pagenow == 'comment.php' || $pagenow == 'edit-comments.php' )
+		if ( $pagenow == 'comment.php' || $pagenow == 'edit-comments.php' ) {
 			wp_die( __( 'Comments are closed.' ), '', array( 'response' => 403 ) );
+		}
 
 		remove_menu_page( 'edit-comments.php' );
 
 		if ( ! $this->discussion_settings_allowed() ) {
-			if ( $pagenow == 'options-discussion.php' )
+			if ( $pagenow == 'options-discussion.php' ) {
 				wp_die( __( 'Comments are closed.' ), '', array( 'response' => 403 ) );
+			}
 
 			remove_submenu_page( 'options-general.php', 'options-discussion.php' );
 		}
 	}
 
-	public function filter_dashboard(){
+	public function filter_dashboard() {
 		remove_meta_box( 'dashboard_recent_comments', 'dashboard', 'normal' );
 	}
 
-	public function admin_css(){
+	public function admin_css() {
 		echo '<style>
 			#dashboard_right_now .comment-count,
 			#dashboard_right_now .comment-mod-count,
@@ -336,7 +338,7 @@ class Disable_Comments {
 		</style>';
 	}
 
-	public function filter_existing_comments($comments, $post_id) {
+	public function filter_existing_comments( $comments, $post_id ) {
 		$post = get_post( $post_id );
 		return ( $this->options['remove_everywhere'] || $this->is_post_type_disabled( $post->post_type ) ) ? array() : $comments;
 	}
@@ -355,7 +357,7 @@ class Disable_Comments {
 		unregister_widget( 'WP_Widget_Recent_Comments' );
 		// The widget has added a style action when it was constructed - which will
 		// still fire even if we now unregister the widget... so filter that out
-		add_filter( 'show_recent_comments_widget_style', '__return_false');
+		add_filter( 'show_recent_comments_widget_style', '__return_false' );
 	}
 
 	public function set_plugin_meta( $links, $file ) {
@@ -369,11 +371,11 @@ class Disable_Comments {
 
 	/**
 	 * Add links to Settings page
-	*/
+	 */
 	public function plugin_actions_links( $links, $file ) {
 		static $plugin;
 		$plugin = plugin_basename( __FILE__ );
-		if( $file == $plugin && current_user_can('manage_options') ) {
+		if ( $file == $plugin && current_user_can( 'manage_options' ) ) {
 			array_unshift(
 				$links,
 				sprintf( '<a href="%s">%s</a>', esc_attr( $this->settings_page_url() ), __( 'Settings' ) ),
@@ -386,10 +388,11 @@ class Disable_Comments {
 
 	public function settings_menu() {
 		$title = _x( 'Disable Comments', 'settings menu title', 'disable-comments' );
-		if( $this->networkactive )
+		if ( $this->networkactive ) {
 			add_submenu_page( 'settings.php', $title, $title, 'manage_network_plugins', 'disable_comments_settings', array( $this, 'settings_page' ) );
-		else
+		} else {
 			add_submenu_page( 'options-general.php', $title, $title, 'manage_options', 'disable_comments_settings', array( $this, 'settings_page' ) );
+		}
 	}
 
 	public function settings_page() {
@@ -398,10 +401,11 @@ class Disable_Comments {
 
 	public function tools_menu() {
 		$title = __( 'Delete Comments', 'disable-comments' );
-		if( $this->networkactive )
+		if ( $this->networkactive ) {
 			add_submenu_page( 'settings.php', $title, $title, 'manage_network_plugins', 'disable_comments_tools', array( $this, 'tools_page' ) );
-		else
+		} else {
 			add_submenu_page( 'tools.php', $title, $title, 'manage_options', 'disable_comments_tools', array( $this, 'tools_page' ) );
+		}
 	}
 
 	public function tools_page() {
@@ -409,7 +413,7 @@ class Disable_Comments {
 	}
 
 	private function discussion_settings_allowed() {
-		if( defined( 'DISABLE_COMMENTS_ALLOW_DISCUSSION_SETTINGS' ) && DISABLE_COMMENTS_ALLOW_DISCUSSION_SETTINGS == true ) {
+		if ( defined( 'DISABLE_COMMENTS_ALLOW_DISCUSSION_SETTINGS' ) && DISABLE_COMMENTS_ALLOW_DISCUSSION_SETTINGS == true ) {
 			return true;
 		}
 	}

--- a/includes/comments-template.php
+++ b/includes/comments-template.php
@@ -1,4 +1,5 @@
 <?php
-/* Dummy comments template file.
+/*
+ Dummy comments template file.
  * This replaces the theme's comment template when comments are disabled everywhere
  */

--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -1,35 +1,37 @@
 <?php
-if( !defined( 'ABSPATH' ) ) {
+if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 $typeargs = array( 'public' => true );
-if( $this->networkactive ) {
-	$typeargs['_builtin'] = true;	// stick to known types for network
+if ( $this->networkactive ) {
+	$typeargs['_builtin'] = true;   // stick to known types for network
 }
 $types = get_post_types( $typeargs, 'objects' );
-foreach( array_keys( $types ) as $type ) {
-	if( ! in_array( $type, $this->modified_types ) && ! post_type_supports( $type, 'comments' ) )	// the type doesn't support comments anyway
-		unset( $types[$type] );
+foreach ( array_keys( $types ) as $type ) {
+	if ( ! in_array( $type, $this->modified_types ) && ! post_type_supports( $type, 'comments' ) ) {   // the type doesn't support comments anyway
+		unset( $types[ $type ] );
+	}
 }
 
 if ( isset( $_POST['submit'] ) ) {
 	check_admin_referer( 'disable-comments-admin' );
 	$this->options['remove_everywhere'] = ( $_POST['mode'] == 'remove_everywhere' );
 
-	if( $this->options['remove_everywhere'] )
+	if ( $this->options['remove_everywhere'] ) {
 		$disabled_post_types = array_keys( $types );
-	else
-		$disabled_post_types =  empty( $_POST['disabled_types'] ) ? array() : (array) $_POST['disabled_types'];
+	} else {
+		$disabled_post_types = empty( $_POST['disabled_types'] ) ? array() : (array) $_POST['disabled_types'];
+	}
 
 	$disabled_post_types = array_intersect( $disabled_post_types, array_keys( $types ) );
 
 	$this->options['disabled_post_types'] = $disabled_post_types;
 
 	// Extra custom post types
-	if( $this->networkactive && !empty( $_POST['extra_post_types'] ) ) {
-		$extra_post_types = array_filter( array_map( 'sanitize_key', explode( ',', $_POST['extra_post_types'] ) ) );
-		$this->options['extra_post_types'] = array_diff( $extra_post_types, array_keys( $types ) );	// Make sure we don't double up builtins
+	if ( $this->networkactive && ! empty( $_POST['extra_post_types'] ) ) {
+		$extra_post_types                  = array_filter( array_map( 'sanitize_key', explode( ',', $_POST['extra_post_types'] ) ) );
+		$this->options['extra_post_types'] = array_diff( $extra_post_types, array_keys( $types ) ); // Make sure we don't double up builtins
 	}
 
 	$this->update_options();
@@ -39,33 +41,38 @@ if ( isset( $_POST['submit'] ) ) {
 ?>
 <style> .indent {padding-left: 2em} </style>
 <div class="wrap">
-<h1><?php _ex( 'Disable Comments', 'settings page title', 'disable-comments') ?></h1>
+<h1><?php _ex( 'Disable Comments', 'settings page title', 'disable-comments' ); ?></h1>
 <?php
-if( $this->networkactive )
-	echo '<div class="updated"><p>' . __( '<em>Disable Comments</em> is Network Activated. The settings below will affect <strong>all sites</strong> in this network.', 'disable-comments') . '</p></div>';
-if( WP_CACHE )
-	echo '<div class="updated"><p>' . __( "It seems that a caching/performance plugin is active on this site. Please manually invalidate that plugin's cache after making any changes to the settings below.", 'disable-comments') . '</p></div>';
+if ( $this->networkactive ) {
+	echo '<div class="updated"><p>' . __( '<em>Disable Comments</em> is Network Activated. The settings below will affect <strong>all sites</strong> in this network.', 'disable-comments' ) . '</p></div>';
+}
+if ( WP_CACHE ) {
+	echo '<div class="updated"><p>' . __( "It seems that a caching/performance plugin is active on this site. Please manually invalidate that plugin's cache after making any changes to the settings below.", 'disable-comments' ) . '</p></div>';
+}
 ?>
 <form action="" method="post" id="disable-comments">
 <ul>
-<li><label for="remove_everywhere"><input type="radio" id="remove_everywhere" name="mode" value="remove_everywhere" <?php checked( $this->options['remove_everywhere'] );?> /> <strong><?php _e( 'Everywhere', 'disable-comments') ?></strong>: <?php _e( 'Disable all comment-related controls and settings in WordPress.', 'disable-comments') ?></label>
-	<p class="indent"><?php printf( __( '%s: This option is global and will affect your entire site. Use it only if you want to disable comments <em>everywhere</em>. A complete description of what this option does is <a href="%s" target="_blank">available here</a>.', 'disable-comments' ), '<strong style="color: #900">' . __('Warning', 'disable-comments') . '</strong>', 'https://wordpress.org/plugins/disable-comments/other_notes/' ); ?></p>
+<li><label for="remove_everywhere"><input type="radio" id="remove_everywhere" name="mode" value="remove_everywhere" <?php checked( $this->options['remove_everywhere'] ); ?> /> <strong><?php _e( 'Everywhere', 'disable-comments' ); ?></strong>: <?php _e( 'Disable all comment-related controls and settings in WordPress.', 'disable-comments' ); ?></label>
+	<p class="indent"><?php printf( __( '%1$s: This option is global and will affect your entire site. Use it only if you want to disable comments <em>everywhere</em>. A complete description of what this option does is <a href="%2$s" target="_blank">available here</a>.', 'disable-comments' ), '<strong style="color: #900">' . __( 'Warning', 'disable-comments' ) . '</strong>', 'https://wordpress.org/plugins/disable-comments/other_notes/' ); ?></p>
 </li>
-<li><label for="selected_types"><input type="radio" id="selected_types" name="mode" value="selected_types" <?php checked( ! $this->options['remove_everywhere'] );?> /> <strong><?php _e( 'On certain post types', 'disable-comments') ?></strong>:</label>
+<li><label for="selected_types"><input type="radio" id="selected_types" name="mode" value="selected_types" <?php checked( ! $this->options['remove_everywhere'] ); ?> /> <strong><?php _e( 'On certain post types', 'disable-comments' ); ?></strong>:</label>
 	<p></p>
 	<ul class="indent" id="listoftypes">
-		<?php foreach( $types as $k => $v ) echo "<li><label for='post-type-$k'><input type='checkbox' name='disabled_types[]' value='$k' ". checked( in_array( $k, $this->options['disabled_post_types'] ), true, false ) ." id='post-type-$k'> {$v->labels->name}</label></li>";?>
+		<?php
+		foreach ( $types as $k => $v ) {
+			echo "<li><label for='post-type-$k'><input type='checkbox' name='disabled_types[]' value='$k' " . checked( in_array( $k, $this->options['disabled_post_types'] ), true, false ) . " id='post-type-$k'> {$v->labels->name}</label></li>";}
+		?>
 	</ul>
-	<?php if( $this->networkactive ) :?>
+	<?php if ( $this->networkactive ) : ?>
 	<p class="indent" id="extratypes"><?php _e( 'Only the built-in post types appear above. If you want to disable comments on other custom post types on the entire network, you can supply a comma-separated list of post types below (use the slug that identifies the post type).', 'disable-comments' ); ?>
 	<br /><label><?php _e( 'Custom post types:', 'disable-comments' ); ?> <input type="text" name="extra_post_types" size="30" value="<?php echo implode( ', ', (array) $this->options['extra_post_types'] ); ?>" /></label></p>
 	<?php endif; ?>
-	<p class="indent"><?php _e( 'Disabling comments will also disable trackbacks and pingbacks. All comment-related fields will also be hidden from the edit/quick-edit screens of the affected posts. These settings cannot be overridden for individual posts.', 'disable-comments') ?></p>
+	<p class="indent"><?php _e( 'Disabling comments will also disable trackbacks and pingbacks. All comment-related fields will also be hidden from the edit/quick-edit screens of the affected posts. These settings cannot be overridden for individual posts.', 'disable-comments' ); ?></p>
 </li>
 </ul>
 
 <?php wp_nonce_field( 'disable-comments-admin' ); ?>
-<p class="submit"><input class="button-primary" type="submit" name="submit" value="<?php _e( 'Save Changes', 'disable-comments') ?>"></p>
+<p class="submit"><input class="button-primary" type="submit" name="submit" value="<?php _e( 'Save Changes', 'disable-comments' ); ?>"></p>
 </form>
 </div>
 <script>

--- a/includes/tools-page.php
+++ b/includes/tools-page.php
@@ -1,109 +1,113 @@
 <?php
-if( !defined( 'ABSPATH' ) ) {
+if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 ?>
 <div class="wrap">
-<h1><?php _e( 'Delete Comments', 'disable-comments') ?></h1>
+<h1><?php _e( 'Delete Comments', 'disable-comments' ); ?></h1>
 <?php
 
 global $wpdb;
-$comments_count = $wpdb->get_var("SELECT count(comment_id) from $wpdb->comments");
-if ( $comments_count <= 0 ) { ?>
-<p><strong><?php _e( 'No comments available for deletion.', 'disable-comments') ?></strong></p>
+$comments_count = $wpdb->get_var( "SELECT count(comment_id) from $wpdb->comments" );
+if ( $comments_count <= 0 ) {
+	?>
+<p><strong><?php _e( 'No comments available for deletion.', 'disable-comments' ); ?></strong></p>
 </div>
-<?php
+	<?php
 	return;
 }
 
 $typeargs = array( 'public' => true );
-if( $this->networkactive ) {
-	$typeargs['_builtin'] = true;	// stick to known types for network
+if ( $this->networkactive ) {
+	$typeargs['_builtin'] = true;   // stick to known types for network
 }
 $types = get_post_types( $typeargs, 'objects' );
-foreach( array_keys( $types ) as $type ) {
-	if( ! in_array( $type, $this->modified_types ) && ! post_type_supports( $type, 'comments' ) )	// the type doesn't support comments anyway
-		unset( $types[$type] );
+foreach ( array_keys( $types ) as $type ) {
+	if ( ! in_array( $type, $this->modified_types ) && ! post_type_supports( $type, 'comments' ) ) {   // the type doesn't support comments anyway
+		unset( $types[ $type ] );
+	}
 }
 
 if ( isset( $_POST['delete'] ) && isset( $_POST['delete_mode'] ) ) {
 	check_admin_referer( 'delete-comments-admin' );
 
-	if( $_POST['delete_mode'] == 'delete_everywhere' ) {
-		if ( $wpdb->query( "TRUNCATE $wpdb->commentmeta" ) != false ){
-            if ( $wpdb->query( "TRUNCATE $wpdb->comments" ) != false ){
-                $wpdb->query( "UPDATE $wpdb->posts SET comment_count = 0 WHERE post_author != 0" );
-                $wpdb->query( "OPTIMIZE TABLE $wpdb->commentmeta" );
-                $wpdb->query( "OPTIMIZE TABLE $wpdb->comments" );
-            	echo "<p style='color:green'><strong>" . __( 'All comments have been deleted.', 'disable-comments' ) . "</strong></p>";
-            } else {
-	            echo "<p style='color:red'><strong>" . __( 'Internal error occured. Please try again later.', 'disable-comments' ) . "</strong></p>";
-            }
-        } else {
-            echo "<p style='color:red'><strong>" . __( 'Internal error occured. Please try again later.', 'disable-comments' ) . "</strong></p>";
-        }
+	if ( $_POST['delete_mode'] == 'delete_everywhere' ) {
+		if ( $wpdb->query( "TRUNCATE $wpdb->commentmeta" ) != false ) {
+			if ( $wpdb->query( "TRUNCATE $wpdb->comments" ) != false ) {
+				$wpdb->query( "UPDATE $wpdb->posts SET comment_count = 0 WHERE post_author != 0" );
+				$wpdb->query( "OPTIMIZE TABLE $wpdb->commentmeta" );
+				$wpdb->query( "OPTIMIZE TABLE $wpdb->comments" );
+				echo "<p style='color:green'><strong>" . __( 'All comments have been deleted.', 'disable-comments' ) . '</strong></p>';
+			} else {
+				echo "<p style='color:red'><strong>" . __( 'Internal error occured. Please try again later.', 'disable-comments' ) . '</strong></p>';
+			}
+		} else {
+			echo "<p style='color:red'><strong>" . __( 'Internal error occured. Please try again later.', 'disable-comments' ) . '</strong></p>';
+		}
 	} else {
-		$delete_post_types =  empty( $_POST['delete_types'] ) ? array() : (array) $_POST['delete_types'];
+		$delete_post_types = empty( $_POST['delete_types'] ) ? array() : (array) $_POST['delete_types'];
 		$delete_post_types = array_intersect( $delete_post_types, array_keys( $types ) );
 
 		// Extra custom post types
-		if( $this->networkactive && !empty( $_POST['delete_extra_post_types'] ) ) {
+		if ( $this->networkactive && ! empty( $_POST['delete_extra_post_types'] ) ) {
 			$delete_extra_post_types = array_filter( array_map( 'sanitize_key', explode( ',', $_POST['delete_extra_post_types'] ) ) );
-			$delete_extra_post_types = array_diff( $delete_extra_post_types, array_keys( $types ) );	// Make sure we don't double up builtins
-			$delete_post_types = array_merge($delete_post_types, $delete_extra_post_types);
+			$delete_extra_post_types = array_diff( $delete_extra_post_types, array_keys( $types ) );    // Make sure we don't double up builtins
+			$delete_post_types       = array_merge( $delete_post_types, $delete_extra_post_types );
 		}
 
 		if ( ! empty( $delete_post_types ) ) {
 			// Loop through post_types and remove comments/meta and set posts comment_count to 0
 			foreach ( $delete_post_types as $delete_post_type ) {
-                $wpdb->query( "DELETE cmeta FROM $wpdb->commentmeta cmeta INNER JOIN $wpdb->comments comments ON cmeta.comment_id=comments.comment_ID INNER JOIN $wpdb->posts posts ON comments.comment_post_ID=posts.ID WHERE posts.post_type = '$delete_post_type'" );
-                $wpdb->query( "DELETE comments FROM $wpdb->comments comments INNER JOIN $wpdb->posts posts ON comments.comment_post_ID=posts.ID WHERE posts.post_type = '$delete_post_type'" );
-                $wpdb->query( "UPDATE $wpdb->posts SET comment_count = 0 WHERE post_author != 0 AND post_type = '$delete_post_type'" );
+				$wpdb->query( "DELETE cmeta FROM $wpdb->commentmeta cmeta INNER JOIN $wpdb->comments comments ON cmeta.comment_id=comments.comment_ID INNER JOIN $wpdb->posts posts ON comments.comment_post_ID=posts.ID WHERE posts.post_type = '$delete_post_type'" );
+				$wpdb->query( "DELETE comments FROM $wpdb->comments comments INNER JOIN $wpdb->posts posts ON comments.comment_post_ID=posts.ID WHERE posts.post_type = '$delete_post_type'" );
+				$wpdb->query( "UPDATE $wpdb->posts SET comment_count = 0 WHERE post_author != 0 AND post_type = '$delete_post_type'" );
 
-                $post_type_object = get_post_type_object( $delete_post_type );
-                $post_type_label = $post_type_object ? $post_type_object->labels->name : $delete_post_type;
-				echo "<p style='color:green'><strong>" . sprintf( __( 'All comments have been deleted for %s.', 'disable-comments' ), $post_type_label ) . "</strong></p>";
+				$post_type_object = get_post_type_object( $delete_post_type );
+				$post_type_label  = $post_type_object ? $post_type_object->labels->name : $delete_post_type;
+				echo "<p style='color:green'><strong>" . sprintf( __( 'All comments have been deleted for %s.', 'disable-comments' ), $post_type_label ) . '</strong></p>';
 			}
 
-            $wpdb->query( "OPTIMIZE TABLE $wpdb->commentmeta" );
-            $wpdb->query( "OPTIMIZE TABLE $wpdb->comments" );
+			$wpdb->query( "OPTIMIZE TABLE $wpdb->commentmeta" );
+			$wpdb->query( "OPTIMIZE TABLE $wpdb->comments" );
 
-            echo "<h4 style='color:green'><strong>" . __( 'Comment Deletion Complete', 'disable-comments') . "</strong></h4>";
+			echo "<h4 style='color:green'><strong>" . __( 'Comment Deletion Complete', 'disable-comments' ) . '</strong></h4>';
 		}
-
 	}
 
-	$comments_count = $wpdb->get_var("SELECT count(comment_id) from $wpdb->comments");
-	if ( $comments_count <= 0 ) { ?>
-		<p><strong><?php _e( 'No comments available for deletion.', 'disable-comments') ?></strong></p>
+	$comments_count = $wpdb->get_var( "SELECT count(comment_id) from $wpdb->comments" );
+	if ( $comments_count <= 0 ) {
+		?>
+		<p><strong><?php _e( 'No comments available for deletion.', 'disable-comments' ); ?></strong></p>
 		</div>
-	<?php
+		<?php
 		return;
 	}
-
 }
 ?>
 <form action="" method="post" id="delete-comments">
 <ul>
-<li><label for="delete_everywhere"><input type="radio" id="delete_everywhere" name="delete_mode" value="delete_everywhere" <?php checked( $this->options['remove_everywhere'] );?> /> <strong><?php _e( 'Everywhere', 'disable-comments') ?></strong>: <?php _e( 'Delete all comments in WordPress.', 'disable-comments') ?></label>
-	<p class="indent"><?php printf( __( '%s: This function and will affect your entire site. Use it only if you want to delete comments <em>everywhere</em>.', 'disable-comments' ), '<strong style="color: #900">' . __('Warning', 'disable-comments') . '</strong>' ); ?></p>
+<li><label for="delete_everywhere"><input type="radio" id="delete_everywhere" name="delete_mode" value="delete_everywhere" <?php checked( $this->options['remove_everywhere'] ); ?> /> <strong><?php _e( 'Everywhere', 'disable-comments' ); ?></strong>: <?php _e( 'Delete all comments in WordPress.', 'disable-comments' ); ?></label>
+	<p class="indent"><?php printf( __( '%s: This function and will affect your entire site. Use it only if you want to delete comments <em>everywhere</em>.', 'disable-comments' ), '<strong style="color: #900">' . __( 'Warning', 'disable-comments' ) . '</strong>' ); ?></p>
 </li>
-<li><label for="selected_delete_types"><input type="radio" id="selected_delete_types" name="delete_mode" value="selected_delete_types" <?php checked( ! $this->options['remove_everywhere'] );?> /> <strong><?php _e( 'For certain post types', 'disable-comments') ?></strong>:</label>
+<li><label for="selected_delete_types"><input type="radio" id="selected_delete_types" name="delete_mode" value="selected_delete_types" <?php checked( ! $this->options['remove_everywhere'] ); ?> /> <strong><?php _e( 'For certain post types', 'disable-comments' ); ?></strong>:</label>
 	<p></p>
 	<ul class="indent" id="listofdeletetypes">
-		<?php foreach( $types as $k => $v ) echo "<li><label for='post-type-$k'><input type='checkbox' name='delete_types[]' value='$k' ". checked( in_array( $k, $this->options['disabled_post_types'] ), true, false ) ." id='post-type-$k'> {$v->labels->name}</label></li>";?>
+		<?php
+		foreach ( $types as $k => $v ) {
+			echo "<li><label for='post-type-$k'><input type='checkbox' name='delete_types[]' value='$k' " . checked( in_array( $k, $this->options['disabled_post_types'] ), true, false ) . " id='post-type-$k'> {$v->labels->name}</label></li>";}
+		?>
 	</ul>
-	<?php if( $this->networkactive ) :?>
+	<?php if ( $this->networkactive ) : ?>
 	<p class="indent" id="extradeletetypes"><?php _e( 'Only the built-in post types appear above. If you want to disable comments on other custom post types on the entire network, you can supply a comma-separated list of post types below (use the slug that identifies the post type).', 'disable-comments' ); ?>
 	<br /><label><?php _e( 'Custom post types:', 'disable-comments' ); ?> <input type="text" name="delete_extra_post_types" size="30" value="<?php echo implode( ', ', (array) $this->options['extra_post_types'] ); ?>" /></label></p>
 	<?php endif; ?>
-	<p class="indent"><?php printf( __( '%s: Deleting comments will remove existing comment entries in the database and cannot be reverted without a database backup.', 'disable-comments'), '<strong style="color: #900">' . __('Warning', 'disable-comments') . '</strong>' ); ?></p>
+	<p class="indent"><?php printf( __( '%s: Deleting comments will remove existing comment entries in the database and cannot be reverted without a database backup.', 'disable-comments' ), '<strong style="color: #900">' . __( 'Warning', 'disable-comments' ) . '</strong>' ); ?></p>
 </li>
 </ul>
 
 <?php wp_nonce_field( 'delete-comments-admin' ); ?>
 <h4><?php _e( 'Total Comments:', 'disable-comments' ); ?> <?php echo $comments_count; ?></h4>
-<p class="submit"><input class="button-primary" type="submit" name="delete" value="<?php _e( 'Delete Comments', 'disable-comments') ?>"></p>
+<p class="submit"><input class="button-primary" type="submit" name="delete" value="<?php _e( 'Delete Comments', 'disable-comments' ); ?>"></p>
 </form>
 </div>
 <script>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,8 +5,8 @@
  * @package Disable_Comments
  */
 
-require_once(dirname(__DIR__) . '/vendor/antecedent/patchwork/Patchwork.php');
-require_once(dirname(__DIR__) . '/vendor/autoload.php');
+require_once( dirname( __DIR__ ) . '/vendor/antecedent/patchwork/Patchwork.php' );
+require_once( dirname( __DIR__ ) . '/vendor/autoload.php' );
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 if ( ! $_tests_dir ) {

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -5,38 +5,40 @@ use Brain\Monkey\Functions;
 
 class RemoveEveryWhereTestCase extends WP_UnitTestCase {
 
-    function setUp() {
-        parent::setUp();
-		update_option( 'disable_comments_options', array(
-			'db_version' => Disable_Comments::DB_VERSION,
-			'remove_everywhere' => true,
-			'disabled_post_types' => array( 'post', 'page', 'attachment' )
-		) );
+	function setUp() {
+		parent::setUp();
+		update_option(
+			'disable_comments_options',
+			array(
+				'db_version'          => Disable_Comments::DB_VERSION,
+				'remove_everywhere'   => true,
+				'disabled_post_types' => array( 'post', 'page', 'attachment' ),
+			)
+		);
 		$this->plugin_instance = new Disable_Comments();
-    }
+	}
 
-    function tearDown()
-    {
-        Monkey::tearDown();
-        parent::tearDown();
-    }
+	function tearDown() {
+		Monkey::tearDown();
+		parent::tearDown();
+	}
 
 	function test_init_hooks_added() {
-		$this->assertEquals( 10,  has_action( 'widgets_init', array( $this->plugin_instance, 'disable_rc_widget' ) ) );
-		$this->assertEquals( 10,  has_action( 'wp_headers', array( $this->plugin_instance, 'filter_wp_headers' ) ) );
-		$this->assertEquals( 9,  has_action( 'template_redirect', array( $this->plugin_instance, 'filter_query' ) ) );
-		$this->assertEquals( 10,  has_action( 'template_redirect', array( $this->plugin_instance, 'filter_admin_bar' ) ) );
-		$this->assertEquals( 10,  has_action( 'admin_init', array( $this->plugin_instance, 'filter_admin_bar' ) ) );
-		$this->assertEquals( 10,  has_action( 'plugins_loaded', array( $this->plugin_instance, 'register_text_domain' ) ) );
-		$this->assertEquals( 10,  has_action( 'wp_loaded', array( $this->plugin_instance, 'init_wploaded_filters' ) ) );
+		$this->assertEquals( 10, has_action( 'widgets_init', array( $this->plugin_instance, 'disable_rc_widget' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_headers', array( $this->plugin_instance, 'filter_wp_headers' ) ) );
+		$this->assertEquals( 9, has_action( 'template_redirect', array( $this->plugin_instance, 'filter_query' ) ) );
+		$this->assertEquals( 10, has_action( 'template_redirect', array( $this->plugin_instance, 'filter_admin_bar' ) ) );
+		$this->assertEquals( 10, has_action( 'admin_init', array( $this->plugin_instance, 'filter_admin_bar' ) ) );
+		$this->assertEquals( 10, has_action( 'plugins_loaded', array( $this->plugin_instance, 'register_text_domain' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_loaded', array( $this->plugin_instance, 'init_wploaded_filters' ) ) );
 	}
 
 	function test_wp_loaded_actions() {
 		$this->plugin_instance->init_wploaded_filters();
-		$this->assertEquals( 20,  has_action( 'comments_array', array( $this->plugin_instance, 'filter_existing_comments' ) ) );
-		$this->assertEquals( 20,  has_action( 'comments_open', array( $this->plugin_instance, 'filter_comment_status' ) ) );
-		$this->assertEquals( 20,  has_action( 'pings_open', array( $this->plugin_instance, 'filter_comment_status' ) ) );
-		$this->assertEquals( 20,  has_action( 'get_comments_number', array( $this->plugin_instance, 'filter_comments_number' ) ) );
+		$this->assertEquals( 20, has_action( 'comments_array', array( $this->plugin_instance, 'filter_existing_comments' ) ) );
+		$this->assertEquals( 20, has_action( 'comments_open', array( $this->plugin_instance, 'filter_comment_status' ) ) );
+		$this->assertEquals( 20, has_action( 'pings_open', array( $this->plugin_instance, 'filter_comment_status' ) ) );
+		$this->assertEquals( 20, has_action( 'get_comments_number', array( $this->plugin_instance, 'filter_comments_number' ) ) );
 
 		// Check that comment suport has been removed from all the post types
 		$this->assertFalse( post_type_supports( 'post', 'comments' ) );
@@ -44,41 +46,41 @@ class RemoveEveryWhereTestCase extends WP_UnitTestCase {
 		$this->assertFalse( post_type_supports( 'attachment', 'comments' ) );
 	}
 
-    function test_wp_loaded_admin_actions() {
-        Functions::when( 'is_admin' )->justReturn(true);
+	function test_wp_loaded_admin_actions() {
+		Functions::when( 'is_admin' )->justReturn( true );
 		$this->plugin_instance->init_wploaded_filters();
 
-        $this->assertEquals( 10,  has_action( 'admin_print_styles-index.php', array( $this->plugin_instance, 'admin_css' ) ) );
-        $this->assertEquals( 10,  has_action( 'admin_print_styles-profile.php', array( $this->plugin_instance, 'admin_css' ) ) );
+		$this->assertEquals( 10, has_action( 'admin_print_styles-index.php', array( $this->plugin_instance, 'admin_css' ) ) );
+		$this->assertEquals( 10, has_action( 'admin_print_styles-profile.php', array( $this->plugin_instance, 'admin_css' ) ) );
 	}
 
-    function test_widget_init_actions() {
-        $this->plugin_instance->disable_rc_widget();
-        $this->assertEquals( 10,  has_filter( 'show_recent_comments_widget_style', '__return_false' ) );
-    }
+	function test_widget_init_actions() {
+		$this->plugin_instance->disable_rc_widget();
+		$this->assertEquals( 10, has_filter( 'show_recent_comments_widget_style', '__return_false' ) );
+	}
 
 	function test_comment_template_filter() {
-		Functions::when( 'is_singular' )->justReturn(true);
-		Functions::when( 'wp_deregister_script' )->justReturn(true);
+		Functions::when( 'is_singular' )->justReturn( true );
+		Functions::when( 'wp_deregister_script' )->justReturn( true );
 		$this->plugin_instance->check_comment_template();
-		# Check that this action was removed
+		// Check that this action was removed
 		$this->assertFalse( has_action( 'wp_head', 'feed_links_extra' ) );
 	}
 
 	function test_filter_headers() {
-		$input = array( 'X-Pingback' => 'http://example.com' );
-		$output = $this->plugin_instance->filter_wp_headers($input);
-		$this->assertEmpty($output);
+		$input  = array( 'X-Pingback' => 'http://example.com' );
+		$output = $this->plugin_instance->filter_wp_headers( $input );
+		$this->assertEmpty( $output );
 	}
 
 	function test_comment_feed_403() {
-		Functions::when( 'is_comment_feed' )->justReturn(true);
+		Functions::when( 'is_comment_feed' )->justReturn( true );
 		Functions::expect( 'wp_die' )->once();
 		$this->plugin_instance->filter_query();
 	}
 
 	function test_admin_bar_filter() {
-		Functions::when( 'is_admin_bar_showing' )->justReturn(true);
+		Functions::when( 'is_admin_bar_showing' )->justReturn( true );
 		add_action( 'admin_bar_menu', 'wp_admin_bar_comments_menu', 60 );
 		$this->plugin_instance->filter_admin_bar();
 		$this->assertFalse( has_action( 'admin_bar_menu', 'wp_admin_bar_comments_menu' ) );
@@ -86,48 +88,51 @@ class RemoveEveryWhereTestCase extends WP_UnitTestCase {
 
 	function test_filter_existing_comments() {
 		$post_id = $this->factory->post->create();
-		$output = $this->plugin_instance->filter_existing_comments( array( 'comment1', 'comment2', 'comment3' ), $post_id );
-		$this->assertEmpty($output);
+		$output  = $this->plugin_instance->filter_existing_comments( array( 'comment1', 'comment2', 'comment3' ), $post_id );
+		$this->assertEmpty( $output );
 	}
 
 	function test_filter_comment_status() {
 		$post_id = $this->factory->post->create();
-		$output = $this->plugin_instance->filter_comment_status( 'open', $post_id );
-		$this->assertFalse($output);
+		$output  = $this->plugin_instance->filter_comment_status( 'open', $post_id );
+		$this->assertFalse( $output );
 	}
 
 	function test_filter_comments_number() {
 		$post_id = $this->factory->post->create();
-		$output = $this->plugin_instance->filter_comments_number( 5, $post_id );
-		$this->assertEquals(0, $output);
+		$output  = $this->plugin_instance->filter_comments_number( 5, $post_id );
+		$this->assertEquals( 0, $output );
 	}
 }
 
 
 class RemoveIndividualTestCase extends WP_UnitTestCase {
 
-    function setUp() {
-        parent::setUp();
+	function setUp() {
+		parent::setUp();
 		$this->reset_post_types();
-		update_option( 'disable_comments_options', array(
-			'db_version' => Disable_Comments::DB_VERSION,
-			'remove_everywhere' => false,
-			'disabled_post_types' => array('post')
-		) );
+		update_option(
+			'disable_comments_options',
+			array(
+				'db_version'          => Disable_Comments::DB_VERSION,
+				'remove_everywhere'   => false,
+				'disabled_post_types' => array( 'post' ),
+			)
+		);
 		$this->plugin_instance = new Disable_Comments();
-    }
+	}
 
 	function test_init_hooks_added() {
-		$this->assertEquals( 10,  has_action( 'plugins_loaded', array( $this->plugin_instance, 'register_text_domain' ) ) );
-		$this->assertEquals( 10,  has_action( 'wp_loaded', array( $this->plugin_instance, 'init_wploaded_filters' ) ) );
+		$this->assertEquals( 10, has_action( 'plugins_loaded', array( $this->plugin_instance, 'register_text_domain' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_loaded', array( $this->plugin_instance, 'init_wploaded_filters' ) ) );
 	}
 
 	function test_wp_loaded_actions() {
 		$this->plugin_instance->init_wploaded_filters();
-		$this->assertEquals( 20,  has_action( 'comments_array', array( $this->plugin_instance, 'filter_existing_comments' ) ) );
-		$this->assertEquals( 20,  has_action( 'comments_open', array( $this->plugin_instance, 'filter_comment_status' ) ) );
-		$this->assertEquals( 20,  has_action( 'pings_open', array( $this->plugin_instance, 'filter_comment_status' ) ) );
-		$this->assertEquals( 20,  has_action( 'get_comments_number', array( $this->plugin_instance, 'filter_comments_number' ) ) );
+		$this->assertEquals( 20, has_action( 'comments_array', array( $this->plugin_instance, 'filter_existing_comments' ) ) );
+		$this->assertEquals( 20, has_action( 'comments_open', array( $this->plugin_instance, 'filter_comment_status' ) ) );
+		$this->assertEquals( 20, has_action( 'pings_open', array( $this->plugin_instance, 'filter_comment_status' ) ) );
+		$this->assertEquals( 20, has_action( 'get_comments_number', array( $this->plugin_instance, 'filter_comments_number' ) ) );
 
 		// Check that comment suport has been removed only from posts
 		$this->assertFalse( post_type_supports( 'post', 'comments' ) );
@@ -136,37 +141,37 @@ class RemoveIndividualTestCase extends WP_UnitTestCase {
 
 	function test_filter_existing_comments_on_disabled_type() {
 		$post_id = $this->factory->post->create();
-		$output = $this->plugin_instance->filter_existing_comments( array( 'comment1', 'comment2', 'comment3' ), $post_id );
-		$this->assertEmpty($output);
+		$output  = $this->plugin_instance->filter_existing_comments( array( 'comment1', 'comment2', 'comment3' ), $post_id );
+		$this->assertEmpty( $output );
 	}
 
 	function test_filter_existing_comments_on_enabled_type() {
 		$post_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		$output = $this->plugin_instance->filter_existing_comments( array( 'comment1', 'comment2', 'comment3' ), $post_id );
-		$this->assertEquals(array( 'comment1', 'comment2', 'comment3' ), $output);
+		$output  = $this->plugin_instance->filter_existing_comments( array( 'comment1', 'comment2', 'comment3' ), $post_id );
+		$this->assertEquals( array( 'comment1', 'comment2', 'comment3' ), $output );
 	}
 
 	function test_filter_comment_status_on_disabled_type() {
 		$post_id = $this->factory->post->create();
-		$output = $this->plugin_instance->filter_comment_status( 'open', $post_id );
+		$output  = $this->plugin_instance->filter_comment_status( 'open', $post_id );
 		$this->assertFalse( $output );
 	}
 
 	function test_filter_comment_status_on_enabled_type() {
 		$post_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		$output = $this->plugin_instance->filter_comment_status( 'open', $post_id );
+		$output  = $this->plugin_instance->filter_comment_status( 'open', $post_id );
 		$this->assertEquals( 'open', $output );
 	}
 
 	function test_filter_comments_number_on_disabled_type() {
 		$post_id = $this->factory->post->create();
-		$output = $this->plugin_instance->filter_comments_number( 5, $post_id );
-		$this->assertEquals(0, $output);
+		$output  = $this->plugin_instance->filter_comments_number( 5, $post_id );
+		$this->assertEquals( 0, $output );
 	}
 
 	function test_filter_comments_number_on_enabled_type() {
 		$post_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		$output = $this->plugin_instance->filter_comments_number( 5, $post_id );
-		$this->assertEquals(5, $output);
+		$output  = $this->plugin_instance->filter_comments_number( 5, $post_id );
+		$this->assertEquals( 5, $output );
 	}
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,5 +1,6 @@
-<?php 
-if( !defined('ABSPATH') && !defined('WP_UNINSTALL_PLUGIN') ) 
+<?php
+if ( ! defined( 'ABSPATH' ) && ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
+}
 
 delete_site_option( 'disable_comments_options' );


### PR DESCRIPTION
Fix some phpcs warnings via phpcbf, can help reduce effort of improving coding style.

```
PHPCBF RESULT SUMMARY
--------------------------------------------------------------------------------------
FILE                                                                  FIXED  REMAINING
--------------------------------------------------------------------------------------
/home/peter/repos/disable-comments/tests/test-plugin.php              94     28
/home/peter/repos/disable-comments/tests/bootstrap.php                8      1
/home/peter/repos/disable-comments/disable-comments.php               158    82
/home/peter/repos/disable-comments/includes/tools-page.php            99     18
/home/peter/repos/disable-comments/includes/settings-page.php         63     10
/home/peter/repos/disable-comments/includes/comments-template.php     2      3
/home/peter/repos/disable-comments/uninstall.php                      12     1
--------------------------------------------------------------------------------------
A TOTAL OF 436 ERRORS WERE FIXED IN 7 FILES
--------------------------------------------------------------------------------------
```

Ref:
  - https://github.com/squizlabs/PHP_CodeSniffer/wiki/Fixing-Errors-Automatically