### PR TITLE
Introduce support for Comment Deletion by Comment Type. 

### DIFF
--- a/includes/tools-page.php
+++ b/includes/tools-page.php
@@ -23,14 +23,29 @@ if ( $comments_count <= 0 ) {
 	return;
 }
 
-$typeargs = array( 'public' => true );
+$publictypeargs = array( 'public' => true );
+$privatetypeargs = array( 'public' => false );
 if ( $this->networkactive ) {
 	$typeargs['_builtin'] = true;   // stick to known types for network.
 }
-$types = get_post_types( $typeargs, 'objects' );
+$publictypes = get_post_types( $publictypeargs, 'objects' );
+$privatetypes = get_post_types( $privatetypeargs, 'objects' );
+$types = array_merge( $publictypes, $privatetypes );
 foreach ( array_keys( $types ) as $type ) {
 	if ( ! in_array( $type, $this->modified_types ) && ! post_type_supports( $type, 'comments' ) ) {   // the type doesn't support comments anyway.
 		unset( $types[ $type ] );
+	}
+}
+$commenttypes = array();
+$commenttypes_query = $wpdb->get_results( "SELECT DISTINCT comment_type FROM $wpdb->comments", ARRAY_A );
+if ( ! empty( $commenttypes_query ) && is_array( $commenttypes_query ) ) {
+	foreach ( $commenttypes_query as $entry ) {
+		$value = $entry['comment_type'];
+		if ( '' === $value ) {
+			$commenttypes['default'] = __( 'Default (no type)', 'disable-comments' );
+		} else {
+			$commenttypes[$value] = ucwords( str_replace( '_', ' ', $value ) ) . ' (' . $value . ')';
+		}
 	}
 }
 
@@ -40,7 +55,7 @@ if ( isset( $_POST['delete'] ) && isset( $_POST['delete_mode'] ) ) {
 	if ( $_POST['delete_mode'] == 'delete_everywhere' ) {
 		if ( $wpdb->query( "TRUNCATE $wpdb->commentmeta" ) != false ) {
 			if ( $wpdb->query( "TRUNCATE $wpdb->comments" ) != false ) {
-				$wpdb->query( "UPDATE $wpdb->posts SET comment_count = 0 WHERE post_author != 0" );
+				$wpdb->query( "UPDATE $wpdb->posts SET comment_count = 0" );
 				$wpdb->query( "OPTIMIZE TABLE $wpdb->commentmeta" );
 				$wpdb->query( "OPTIMIZE TABLE $wpdb->comments" );
 				echo "<p style='color:green'><strong>" . __( 'All comments have been deleted.', 'disable-comments' ) . '</strong></p>';
@@ -50,7 +65,7 @@ if ( isset( $_POST['delete'] ) && isset( $_POST['delete_mode'] ) ) {
 		} else {
 			echo "<p style='color:red'><strong>" . __( 'Internal error occured. Please try again later.', 'disable-comments' ) . '</strong></p>';
 		}
-	} else {
+	} elseif ( $_POST['delete_mode'] == 'selected_delete_types' ) {
 		$delete_post_types = empty( $_POST['delete_types'] ) ? array() : (array) $_POST['delete_types'];
 		$delete_post_types = array_intersect( $delete_post_types, array_keys( $types ) );
 
@@ -78,6 +93,30 @@ if ( isset( $_POST['delete'] ) && isset( $_POST['delete_mode'] ) ) {
 
 			echo "<h4 style='color:green'><strong>" . __( 'Comment Deletion Complete', 'disable-comments' ) . '</strong></h4>';
 		}
+	} elseif ( $_POST['delete_mode'] == 'selected_delete_comment_types' ) {
+		$delete_comment_types = empty( $_POST['delete_comment_types'] ) ? array() : (array) $_POST['delete_comment_types'];
+		$delete_comment_types = array_intersect( $delete_comment_types, array_keys( $commenttypes ) );
+
+		if ( ! empty( $delete_comment_types ) ) {
+			// Loop through comment_types and remove comments/meta and set posts comment_count to 0.
+			foreach ( $delete_comment_types as $delete_comment_type ) {
+				$wpdb->query( "DELETE cmeta FROM $wpdb->commentmeta cmeta INNER JOIN $wpdb->comments comments ON cmeta.comment_id=comments.comment_ID WHERE comments.comment_type = '$delete_comment_type'" );
+				$wpdb->query( "DELETE comments FROM $wpdb->comments comments  WHERE comments.comment_type = '$delete_comment_type'" );
+				
+				echo "<p style='color:green'><strong>" . sprintf( __( 'All comments have been deleted for %s.', 'disable-comments' ), $commenttypes[$delete_comment_type] ) . '</strong></p>';
+			}
+
+			// Update comment_count on post_types
+			foreach( $types as $key => $value ) {
+				$comment_count = $wpdb->get_var( "SELECT COUNT(comments.comment_ID) FROM $wpdb->comments comments INNER JOIN $wpdb->posts posts ON comments.comment_post_ID=posts.ID WHERE posts.post_type = '$key'" );
+				$wpdb->query( "UPDATE $wpdb->posts SET comment_count = $comment_count WHERE post_author != 0 AND post_type = '$key'" );
+			}
+
+			$wpdb->query( "OPTIMIZE TABLE $wpdb->commentmeta" );
+			$wpdb->query( "OPTIMIZE TABLE $wpdb->comments" );
+
+			echo "<h4 style='color:green'><strong>" . __( 'Comment Deletion Complete', 'disable-comments' ) . '</strong></h4>';
+		}		
 	}
 
 	$comments_count = $wpdb->get_var( "SELECT count(comment_id) from $wpdb->comments" );
@@ -107,8 +146,20 @@ if ( isset( $_POST['delete'] ) && isset( $_POST['delete_mode'] ) ) {
 	<p class="indent" id="extradeletetypes"><?php _e( 'Only the built-in post types appear above. If you want to disable comments on other custom post types on the entire network, you can supply a comma-separated list of post types below (use the slug that identifies the post type).', 'disable-comments' ); ?>
 	<br /><label><?php _e( 'Custom post types:', 'disable-comments' ); ?> <input type="text" name="delete_extra_post_types" size="30" value="<?php echo implode( ', ', (array) $this->options['extra_post_types'] ); ?>" /></label></p>
 	<?php endif; ?>
-	<p class="indent"><?php printf( __( '%s: Deleting comments will remove existing comment entries in the database and cannot be reverted without a database backup.', 'disable-comments' ), '<strong style="color: #900">' . __( 'Warning', 'disable-comments' ) . '</strong>' ); ?></p>
+	<p class="indent"><?php printf( __( '%s: Deleting comments by post type will remove existing comment entries for the selected post type(s) in the database and cannot be reverted without a database backup.', 'disable-comments' ), '<strong style="color: #900">' . __( 'Warning', 'disable-comments' ) . '</strong>' ); ?></p>
 </li>
+<?php if ( ! empty( $commenttypes ) ) : ?>
+<li><label for="selected_delete_comment_types"><input type="radio" id="selected_delete_comment_types" name="delete_mode" value="selected_delete_comment_types" /> <strong><?php _e( 'For certain comment types', 'disable-comments' ); ?></strong>:</label>
+	<p></p>
+	<ul class="indent" id="listofdeletecommenttypes">
+		<?php
+		foreach ( $commenttypes as $k => $v ) {
+			echo "<li><label for='comment-type-$k'><input type='checkbox' name='delete_comment_types[]' value='$k' id='comment-type-$k'> {$v}</label></li>";}
+		?>
+	</ul>
+	<p class="indent"><?php printf( __( '%s: Deleting comments by comment type will remove existing comment entries of the selected comment type(s) in the database and cannot be reverted without a database backup.', 'disable-comments' ), '<strong style="color: #900">' . __( 'Warning', 'disable-comments' ) . '</strong>' ); ?></p>
+</li>
+<?php endif; ?>
 </ul>
 
 <?php wp_nonce_field( 'delete-comments-admin' ); ?>
@@ -119,11 +170,20 @@ if ( isset( $_POST['delete'] ) && isset( $_POST['delete_mode'] ) ) {
 <script>
 jQuery(document).ready(function($){
 	function delete_comments_uihelper(){
-		var toggle_bits = $("#listofdeletetypes, #extradeletetypes");
-		if( $("#delete_everywhere").is(":checked") )
-			toggle_bits.css("color", "#888").find(":input").attr("disabled", true );
-		else
-			toggle_bits.css("color", "#000").find(":input").attr("disabled", false );
+		var toggle_pt_bits = $("#listofdeletetypes, #extradeletetypes");
+		var toggle_ct_bits = $("#listofdeletecommenttypes");
+		if( $("#delete_everywhere").is(":checked") ) {
+			toggle_pt_bits.css("color", "#888").find(":input").attr("disabled", true );
+			toggle_ct_bits.css("color", "#888").find(":input").attr("disabled", true );
+		} else {
+			if( $("#selected_delete_types").is(":checked") ) {
+				toggle_pt_bits.css("color", "#000").find(":input").attr("disabled", false );
+				toggle_ct_bits.css("color", "#888").find(":input").attr("disabled", true );
+			} else {
+				toggle_ct_bits.css("color", "#000").find(":input").attr("disabled", false );
+				toggle_pt_bits.css("color", "#888").find(":input").attr("disabled", true );
+			}
+		}
 	}
 
 	$("#delete-comments :input").change(function(){


### PR DESCRIPTION
With support for Comment Type deletion this fixes #87 

@solarissmoke please review. Below is an updated screenshot;
<img width="784" alt="Screen Shot 2020-02-20 at 1 55 31 PM" src="https://user-images.githubusercontent.com/8726005/74982385-dfc57800-53e8-11ea-9c20-42568041902e.png">

While working through the Comment Type I found a few other minor issues I've addressed.
1. Update Comment Deletion by Post Type to support Private Post Types. (With WooCommerce the Order Notes and Action Scheduler are private post types, but they hold comments in the DB so this allows for them to be deleted selectively).
2. Update Comment Deletion everywhere to update comment_count for all post types. Currently it doesn't clear the Scheduled Actions post type as it's post_author was 0.

Looking back we could avoid the deletion by comment_type if we just support the private post types as Orders and Scheduled Actions cover the two comment_types from my tests (action_log => Scheduled Actions, order_note => Orders). That being said other plugins could maybe not have a one-to-one relationship between their post_types and comment_type. Let me know if you want me to trim the comment_type deletion @solarissmoke.

Also if desired we can have a constant or flag to enable the private post types support.

Thoughts?